### PR TITLE
added "version" key to manifest.json to comply with Home Assistant 2021.6

### DIFF
--- a/custom_components/unsplash/manifest.json
+++ b/custom_components/unsplash/manifest.json
@@ -2,6 +2,7 @@
   "domain": "unsplash",
   "name": "Unsplash",
   "documentation": "https://github.com/custom-components/unsplash",
+  "version": "0.6.2",
   "dependencies": [],
   "codeowners": [
     "@ludeeus"


### PR DESCRIPTION
Home Assistant 2021.6 requires the "version" key in manifest.json
added version as "0.6.2" 